### PR TITLE
Add videos and resources sections

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -7,9 +7,11 @@ import { SITE_TITLE } from '../consts';
 	<nav>
 		<h2><a href="/">{SITE_TITLE}</a></h2>
 		<div class="internal-links">
-			<HeaderLink href="/">Home</HeaderLink>
-			<HeaderLink href="/blog">Blog</HeaderLink>
-			<HeaderLink href="/about">About</HeaderLink>
+                        <HeaderLink href="/">Home</HeaderLink>
+                        <HeaderLink href="/blog">Blog</HeaderLink>
+                        <HeaderLink href="/videos">Videos</HeaderLink>
+                        <HeaderLink href="/resources">Resources</HeaderLink>
+                        <HeaderLink href="/about">About</HeaderLink>
 		</div>
 		<div class="social-links">
 			<a href="https://m.webtoo.ls/@astro" target="_blank">

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -15,4 +15,26 @@ const blog = defineCollection({
 	}),
 });
 
-export const collections = { blog };
+const videos = defineCollection({
+        loader: glob({ base: './src/content/videos', pattern: '**/*.mdx' }),
+        schema: ({ image }) =>
+                z.object({
+                        title: z.string(),
+                        date: z.coerce.date(),
+                        tags: z.array(z.string()).optional(),
+                        heroImage: image().optional(),
+                }),
+});
+
+const resources = defineCollection({
+        loader: glob({ base: './src/content/resources', pattern: '**/*.mdx' }),
+        schema: ({ image }) =>
+                z.object({
+                        title: z.string(),
+                        date: z.coerce.date(),
+                        tags: z.array(z.string()).optional(),
+                        heroImage: image().optional(),
+                }),
+});
+
+export const collections = { blog, videos, resources };

--- a/src/content/resources/getting-started.mdx
+++ b/src/content/resources/getting-started.mdx
@@ -1,0 +1,9 @@
+---
+title: "Getting Started"
+date: "2023-01-10"
+tags:
+  - guide
+  - resource
+---
+
+This is a placeholder for the first resource entry.

--- a/src/content/videos/intro-video.mdx
+++ b/src/content/videos/intro-video.mdx
@@ -1,0 +1,9 @@
+---
+title: "Introduction Video"
+date: "2023-01-05"
+tags:
+  - intro
+  - video
+---
+
+This is a placeholder for the first video content.

--- a/src/pages/resources.astro
+++ b/src/pages/resources.astro
@@ -1,0 +1,61 @@
+---
+import BaseHead from '../components/BaseHead.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
+import { getCollection } from 'astro:content';
+import FormattedDate from '../components/FormattedDate.astro';
+import { Image } from 'astro:assets';
+
+const posts = (await getCollection('resources')).sort((a,b) => b.data.date.valueOf() - a.data.date.valueOf());
+---
+
+<!doctype html>
+<html lang="en">
+    <head>
+        <BaseHead title={`${SITE_TITLE} | Resources`} description={SITE_DESCRIPTION} />
+        <style>
+            main { width: 960px; }
+            ul { display:flex; flex-wrap:wrap; gap:2rem; list-style-type:none; margin:0; padding:0; }
+            ul li { width: calc(50% - 1rem); }
+            ul li * { text-decoration:none; transition:0.2s ease; }
+            ul li:first-child { width:100%; margin-bottom:1rem; text-align:center; }
+            ul li:first-child img { width:100%; }
+            ul li:first-child .title { font-size:2.369rem; }
+            ul li img { margin-bottom:0.5rem; border-radius:12px; }
+            ul li a { display:block; }
+            .title { margin:0; color: rgb(var(--black)); line-height:1; }
+            .date, .tags { margin:0; color: rgb(var(--gray)); }
+            ul li a:hover h4, ul li a:hover .date { color: rgb(var(--accent)); }
+            ul a:hover img { box-shadow: var(--box-shadow); }
+            @media (max-width: 720px) {
+                ul { gap:0.5em; }
+                ul li { width:100%; text-align:center; }
+                ul li:first-child { margin-bottom:0; }
+                ul li:first-child .title { font-size:1.563em; }
+            }
+        </style>
+    </head>
+    <body>
+        <Header />
+        <main>
+            <section>
+                <ul>
+                    {
+                        posts.map(post => (
+                            <li>
+                                <a href={`/resources/${post.id}/`}>
+                                    {post.data.heroImage && (<Image width={720} height={360} src={post.data.heroImage} alt="" />)}
+                                    <h4 class="title">{post.data.title}</h4>
+                                    <p class="date"><FormattedDate date={post.data.date} /></p>
+                                    {post.data.tags && (<p class="tags">{post.data.tags.join(', ')}</p>)}
+                                </a>
+                            </li>
+                        ))
+                    }
+                </ul>
+            </section>
+        </main>
+        <Footer />
+    </body>
+</html>

--- a/src/pages/videos.astro
+++ b/src/pages/videos.astro
@@ -1,0 +1,61 @@
+---
+import BaseHead from '../components/BaseHead.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
+import { getCollection } from 'astro:content';
+import FormattedDate from '../components/FormattedDate.astro';
+import { Image } from 'astro:assets';
+
+const posts = (await getCollection('videos')).sort((a,b) => b.data.date.valueOf() - a.data.date.valueOf());
+---
+
+<!doctype html>
+<html lang="en">
+    <head>
+        <BaseHead title={`${SITE_TITLE} | Videos`} description={SITE_DESCRIPTION} />
+        <style>
+            main { width: 960px; }
+            ul { display:flex; flex-wrap:wrap; gap:2rem; list-style-type:none; margin:0; padding:0; }
+            ul li { width: calc(50% - 1rem); }
+            ul li * { text-decoration:none; transition:0.2s ease; }
+            ul li:first-child { width:100%; margin-bottom:1rem; text-align:center; }
+            ul li:first-child img { width:100%; }
+            ul li:first-child .title { font-size:2.369rem; }
+            ul li img { margin-bottom:0.5rem; border-radius:12px; }
+            ul li a { display:block; }
+            .title { margin:0; color: rgb(var(--black)); line-height:1; }
+            .date, .tags { margin:0; color: rgb(var(--gray)); }
+            ul li a:hover h4, ul li a:hover .date { color: rgb(var(--accent)); }
+            ul a:hover img { box-shadow: var(--box-shadow); }
+            @media (max-width: 720px) {
+                ul { gap:0.5em; }
+                ul li { width:100%; text-align:center; }
+                ul li:first-child { margin-bottom:0; }
+                ul li:first-child .title { font-size:1.563em; }
+            }
+        </style>
+    </head>
+    <body>
+        <Header />
+        <main>
+            <section>
+                <ul>
+                    {
+                        posts.map(post => (
+                            <li>
+                                <a href={`/videos/${post.id}/`}>
+                                    {post.data.heroImage && (<Image width={720} height={360} src={post.data.heroImage} alt="" />)}
+                                    <h4 class="title">{post.data.title}</h4>
+                                    <p class="date"><FormattedDate date={post.data.date} /></p>
+                                    {post.data.tags && (<p class="tags">{post.data.tags.join(', ')}</p>)}
+                                </a>
+                            </li>
+                        ))
+                    }
+                </ul>
+            </section>
+        </main>
+        <Footer />
+    </body>
+</html>


### PR DESCRIPTION
## Summary
- add `/videos` and `/resources` sections
- list markdown files in these new sections
- add new navigation links
- define collections for videos and resources
- add example MDX entries

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530775ed78832c9189e3046a667024