### PR TITLE
Add YouTube embed component and example video

### DIFF
--- a/src/components/YouTubeEmbed.astro
+++ b/src/components/YouTubeEmbed.astro
@@ -1,0 +1,22 @@
+---
+interface Props {
+    videoId: string;
+}
+
+const { videoId } = Astro.props;
+const thumbnail = `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
+const url = `https://www.youtube.com/watch?v=${videoId}`;
+---
+
+<a href={url} target="_blank" rel="noopener noreferrer" class="yt-thumb">
+    <img src={thumbnail} alt="Watch on YouTube" loading="lazy" />
+</a>
+
+<style>
+    .yt-thumb img {
+        width: 100%;
+        height: auto;
+        display: block;
+        border-radius: 8px;
+    }
+</style>

--- a/src/content/videos/example-video.mdx
+++ b/src/content/videos/example-video.mdx
@@ -1,0 +1,11 @@
+---
+title: "Example Video"
+date: "2024-01-01"
+tags:
+  - sample
+  - video
+---
+
+import YouTubeEmbed from '../../components/YouTubeEmbed.astro'
+
+<YouTubeEmbed videoId="dQw4w9WgXcQ" />

--- a/src/layouts/VideoPost.astro
+++ b/src/layouts/VideoPost.astro
@@ -1,0 +1,81 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import BaseHead from '../components/BaseHead.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import FormattedDate from '../components/FormattedDate.astro';
+
+import { Image } from 'astro:assets';
+
+type Props = CollectionEntry<'videos'>['data'];
+
+const { title, date, tags, heroImage } = Astro.props as Props;
+---
+
+<html lang="en">
+  <head>
+    <BaseHead title={title} description={title} />
+    <style>
+      main {
+        width: calc(100% - 2em);
+        max-width: 100%;
+        margin: 0;
+      }
+      .hero-image {
+        width: 100%;
+      }
+      .hero-image img {
+        display: block;
+        margin: 0 auto;
+        border-radius: 12px;
+        box-shadow: var(--box-shadow);
+      }
+      .prose {
+        width: 720px;
+        max-width: calc(100% - 2em);
+        margin: auto;
+        padding: 1em;
+        color: rgb(var(--gray-dark));
+      }
+      .title {
+        margin-bottom: 1em;
+        padding: 1em 0;
+        text-align: center;
+        line-height: 1;
+      }
+      .title h1 {
+        margin: 0 0 0.5em 0;
+      }
+      .date {
+        margin-bottom: 0.5em;
+        color: rgb(var(--gray));
+      }
+      .tags {
+        margin-top: 0;
+        color: rgb(var(--gray));
+      }
+    </style>
+  </head>
+  <body>
+    <Header />
+    <main>
+      <article>
+        {heroImage && (
+          <div class="hero-image">
+            <Image width={1020} height={510} src={heroImage} alt="" />
+          </div>
+        )}
+        <div class="prose">
+          <div class="title">
+            <p class="date"><FormattedDate date={date} /></p>
+            <h1>{title}</h1>
+            {tags && <p class="tags">{tags.join(', ')}</p>}
+            <hr />
+          </div>
+          <slot />
+        </div>
+      </article>
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/src/pages/videos/[...slug].astro
+++ b/src/pages/videos/[...slug].astro
@@ -1,0 +1,22 @@
+---
+import { type CollectionEntry, getCollection } from 'astro:content';
+import VideoPost from '../../layouts/VideoPost.astro';
+import { render } from 'astro:content';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('videos');
+  return posts.map((post) => ({
+    params: { slug: post.id },
+    props: post,
+  }));
+}
+
+type Props = CollectionEntry<'videos'>;
+
+const post = Astro.props as Props;
+const { Content } = await render(post);
+---
+
+<VideoPost {...post.data}>
+  <Content />
+</VideoPost>


### PR DESCRIPTION
## Summary
- add a reusable `YouTubeEmbed` Astro component
- add `example-video.mdx` showing how to embed a YouTube thumbnail
- create a `VideoPost` layout and dynamic route for video pages

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530be21dbc832cb54f0a75fe416ad4